### PR TITLE
Add support for Picovoice wakeword detection

### DIFF
--- a/openai_api_chatbot.py
+++ b/openai_api_chatbot.py
@@ -3,13 +3,17 @@ import os
 import whisper
 import pygame
 
+#if these are below they are useless, the import on VirtualAssistant needs them
+os.environ['OPENAI_API_KEY']  = 'your-openai-api-key'
+os.environ['IBM_API_KEY']     = 'your-ibm-cloud-api-key'
+os.environ['IBM_TTS_SERVICE'] = 'your-ibm-cloud-tts-url'
+#added procupine key variable
+os.environ['PORCUPINE_KEY'] = 'your-free-porcupine-key'
+
 from Assistant import get_audio as myaudio
 from Assistant.VirtualAssistant import VirtualAssistant
 from Assistant.tools import count_tokens
 
-os.environ['OPENAI_API_KEY']  = 'your-openai-api-key'
-os.environ['IBM_API_KEY']     = 'your-ibm-cloud-api-key'
-os.environ['IBM_TTS_SERVICE'] = 'your-ibm-cloud-tts-url'
 
 print('DONE\n')
 
@@ -46,8 +50,8 @@ if __name__=="__main__":
         if not(jarvis.is_awake):
             print('\n awaiting for triggering words...')
 
-            while not(jarvis.is_awake):
-                jarvis.listen_passively()
+            #block until the wakeword is heard, using porcupine
+            jarvis.block_until_wakeword()
         
         jarvis.record_to_file('output.wav')
         

--- a/openai_api_chatbot.py
+++ b/openai_api_chatbot.py
@@ -9,6 +9,7 @@ os.environ['IBM_API_KEY']     = 'your-ibm-cloud-api-key'
 os.environ['IBM_TTS_SERVICE'] = 'your-ibm-cloud-tts-url'
 #added procupine key variable
 os.environ['PORCUPINE_KEY'] = 'your-free-porcupine-key'
+use_porcupine = True
 
 from Assistant import get_audio as myaudio
 from Assistant.VirtualAssistant import VirtualAssistant
@@ -51,7 +52,11 @@ if __name__=="__main__":
             print('\n awaiting for triggering words...')
 
             #block until the wakeword is heard, using porcupine
-            jarvis.block_until_wakeword()
+            if use_porcupine:
+                jarvis.block_until_wakeword()
+            else:
+                while not(jarvis.is_awake):
+                    jarvis.listen_passively()
         
         jarvis.record_to_file('output.wav')
         


### PR DESCRIPTION
I had issues using Whisper to activate the Assistant, mainly when I tried out different wake words like "Jarvis" where it mislabeled the speech. To fix this I used [PicoVoice Porcupine](https://picovoice.ai/docs/quick-start/porcupine-python/), which already has an impressively accurate model for the Jarvis wake-word, even picking it up clearly with decently loud worded music playing.

Picovoice runs entirely locally and is completely free to train new models for customized wake words and use. It does require the module pvporcupine to be installed. ```pip install pvporcupine``` But it is just a couple of MB, so install time shouldn't be too affected. 

the main change is the ```block_until_wakeword``` function, which stops the loop until Porcupine is triggered. A note with Picovoice is that you can tell which word triggered the function, so it is possible that calling a different trigger word could be used to do different things. Implementations like user profiles, specialized functionality like local operations, web search, and more are possible with relative ease.  

Other than that, I added a flag and environment variable to hold the PicoVoice key, as well as moved the block setting the key values to above the Assitant import calls. The last change is due to some errors I would get during startup in the Assistant file, due to the environment variables not being set before the importing of the class and it running the ```__init__``` function. 

Note: you have the .env file, but it is not activated or used in the actual program. This could be very useful.

I think I am going to work on a script that automates the installation of the process and sets the keys for users. That way there are clear and structured prompts.